### PR TITLE
Fix: rename Hooks directory to hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/build


### PR DESCRIPTION
Renamed the Hooks directory to hooks to resolve case-sensitivity issues.
This change fixes the Module not found error and allows the app to start correctly.